### PR TITLE
Fix backend package.json syntax

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -7,7 +7,7 @@
     "dev": "ts-node-dev --respawn src/index.ts",
     "start": "node dist/index.js",
     "build": "tsc",
-    "test": "jest"
+    "test": "jest",
     "postinstall": "prisma generate"
   },
   "keywords": [],


### PR DESCRIPTION
## Summary
- fix missing comma in backend/package.json

## Testing
- `npm install --ignore-scripts --no-audit --progress=false` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@types%2fjest)*

------
https://chatgpt.com/codex/tasks/task_e_6844a35ee2108328a763bf8c379f804b