### PR TITLE
Copy prisma dir in Dockerfile

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -3,6 +3,7 @@ FROM node:20-alpine
 WORKDIR /app
 
 COPY package*.json ./
+COPY prisma ./prisma
 RUN npm install
 
 COPY . .


### PR DESCRIPTION
## Summary
- copy `prisma/` directory before running `npm install`

## Testing
- `npm test` *(fails: Invalid package.json)*
- `docker build -t hydra-backend ./backend` *(fails: `docker` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844a3630c108328a568c75f28f40a06