### PR TITLE
Add Codex setup script

### DIFF
--- a/.codex.yaml
+++ b/.codex.yaml
@@ -1,0 +1,1 @@
+setup_script: .codex/setup.sh

--- a/.codex/setup.sh
+++ b/.codex/setup.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -euo pipefail
+cd "$(dirname "$0")"
+
+# ensure Node version from .nvmrc
+source "$HOME/.nvm/nvm.sh"
+nvm install
+
+# install backend dependencies and generate Prisma client
+pushd backend
+npm ci
+popd
+
+# install frontend dependencies
+pushd frontend
+npm ci
+popd


### PR DESCRIPTION
## Summary
- add Codex setup script
- configure `.codex.yaml` to point to the script

## Testing
- `npm ci` *(fails: 403 Forbidden)
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844acd0db8483289b2eb5740dc0aaf9