### PR TITLE
Fix setup script path

### DIFF
--- a/.codex/setup.sh
+++ b/.codex/setup.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -euo pipefail
-cd "$(dirname "$0")"
+cd "$(dirname "$0")"/..
 
 # ensure Node version from .nvmrc
 source "$HOME/.nvm/nvm.sh"


### PR DESCRIPTION
## Summary
- ensure setup script moves into repo root

## Testing
- `bash .codex/setup.sh` *(fails: 403 Forbidden fetching Prisma engine)*

------
https://chatgpt.com/codex/tasks/task_e_6844be7e9e3083288681af7ff2dfc3ae